### PR TITLE
[Improvement] Add Error Component Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A flexible-width <Image> component for React Native using `aspectRatio`
 $ yarn add react-native-flex-image
 ```
 
- -- or --
+-- or --
 
- ```
- $ npm install react-native-flex-image --save
- ```
+```
+$ npm install react-native-flex-image --save
+```
 
 ## Usage
 
@@ -45,6 +45,7 @@ function App() {
 ```
 
 #### Local Image
+
 ```js
 import FlexImage from 'react-native-flex-image';
 
@@ -58,6 +59,7 @@ function App() {
 ```
 
 #### With onPress Event
+
 ```js
 import FlexImage from 'react-native-flex-image';
 
@@ -73,7 +75,7 @@ function App() {
           this.setState({
             imageClickCount: imageClickCount + 1,
           });
-         }}
+        }}
       />
     </View>
   );
@@ -81,6 +83,7 @@ function App() {
 ```
 
 #### Custom Loading Component
+
 ```js
 import FlexImage from 'react-native-flex-image';
 
@@ -91,9 +94,7 @@ function App() {
         source={{
           uri: 'image source uri',
         }}
-        loadingComponent={
-          <ActivityIndicator size="large" color="red" />
-        }
+        loadingComponent={<ActivityIndicator size="large" color="red" />}
       />
     </View>
   );
@@ -101,6 +102,7 @@ function App() {
 ```
 
 #### Progressive Loading Component
+
 ```js
 import FlexImage from 'react-native-flex-image';
 
@@ -120,17 +122,18 @@ function App() {
 ```
 
 ## Properties
-*Note: Other properties will be passed down to underlying image component.*
 
-| Prop | Type | Description | Default |
-|---|---|---|---|
-|**`source`**|required|source of the image|*None*|
-|**`onPress`**|optional|onPress event when user clicking the image|`null`|
-|**`style`**|optional|custom style for the image container |`null`|
-|**`loadingComponent`**|optional|custom loading indicator when render the image |`<ActivityIndicator animating={true} size="large" />`|
-|**`thumbnail`**|optional|source of the thumbnail|*None*|
-|**`loadingMethod`**|optional|enum for select loading method, using `indicator` or `progressive`|`indicator`|
+_Note: Other properties will be passed down to underlying image component._
 
+| Prop                   | Type     | Description                                                        | Default                                               |
+| ---------------------- | -------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| **`source`**           | required | source of the image                                                | _None_                                                |
+| **`onPress`**          | optional | onPress event when user clicking the image                         | `null`                                                |
+| **`style`**            | optional | custom style for the image container                               | `null`                                                |
+| **`loadingComponent`** | optional | custom loading indicator when render the image                     | `<ActivityIndicator animating={true} size="large" />` |
+| **`thumbnail`**        | optional | source of the thumbnail                                            | _None_                                                |
+| **`loadingMethod`**    | optional | enum for select loading method, using `indicator` or `progressive` | `indicator`                                           |
+| **`errorComponent`**   | optional | custom error component when fail displaying the image              | `null`                                                |
 
 ## License
 

--- a/src/FlexImage.js
+++ b/src/FlexImage.js
@@ -17,12 +17,13 @@ type Cancellable = {
 };
 
 type Props = {
-  source: number | { uri: string, width?: number, height?: number },
+  source: number | {uri: string, width?: number, height?: number},
   style?: StyleType,
   loadingComponent?: ReactNode,
   onPress?: () => void,
-  thumbnail?: number | { uri: string, width?: number, height?: number },
+  thumbnail?: number | {uri: string, width?: number, height?: number},
   loadingMethod?: 'spinner' | 'progressive',
+  errorComponent?: ReactNode,
 };
 
 type State = {
@@ -60,7 +61,7 @@ export default class FlexImage extends Component<Props, State> {
       this._pendingGetSize = getImageSize(
         src,
         this._onLoadSuccess,
-        this._onLoadFail
+        this._onLoadFail,
       );
     }
 
@@ -86,6 +87,7 @@ export default class FlexImage extends Component<Props, State> {
       loadingComponent,
       thumbnail,
       loadingMethod,
+      errorComponent,
       ...otherProps
     } = this.props;
     let {isLoading, ratio, error, thumbnailOpacity} = this.state;
@@ -104,7 +106,7 @@ export default class FlexImage extends Component<Props, State> {
     if (error) {
       return (
         <View style={[{justifyContent: 'center', alignItems: 'center'}, style]}>
-          <Text>{error}</Text>
+          {errorComponent ? errorComponent : <Text>{error}</Text>}
         </View>
       );
     }
@@ -124,21 +126,20 @@ export default class FlexImage extends Component<Props, State> {
         disabled={!onPress}
         style={[{aspectRatio: ratio}, style]}
       >
-        {thumbnail &&
-          loadingMethod === 'progressive' && (
-            <Animated.Image
-              {...otherProps}
-              source={thumbnail}
-              style={{
-                width: '100%',
-                height: '100%',
-                opacity: thumbnailOpacity,
-                zIndex: 1,
-              }}
-              onLoad={this._onThumbnailLoad}
-              testID="progressiveThumbnail"
-            />
-          )}
+        {thumbnail && loadingMethod === 'progressive' && (
+          <Animated.Image
+            {...otherProps}
+            source={thumbnail}
+            style={{
+              width: '100%',
+              height: '100%',
+              opacity: thumbnailOpacity,
+              zIndex: 1,
+            }}
+            onLoad={this._onThumbnailLoad}
+            testID="progressiveThumbnail"
+          />
+        )}
         <Animated.Image
           {...otherProps}
           source={imageSource}
@@ -181,9 +182,9 @@ export default class FlexImage extends Component<Props, State> {
 
 // A cancellable version of Image.getSize
 export function getImageSize(
-  source: { uri: string },
+  source: {uri: string},
   onSuccess: (width: number, height: number) => void,
-  onFail: (error: Error) => void
+  onFail: (error: Error) => void,
 ) {
   let isCancelled = false;
   Image.getSize(
@@ -197,7 +198,7 @@ export function getImageSize(
       if (!isCancelled) {
         onFail(error);
       }
-    }
+    },
   );
   return {
     cancel: () => {


### PR DESCRIPTION
adding custom error component in shape of ReactNode which to be displayed when failed to display the image. Before, it's only error text